### PR TITLE
Enhance monitor-canary.sh for better canary visibility in the advanced-deployments folder

### DIFF
--- a/advanced-deployments/scripts/monitor-canary.sh
+++ b/advanced-deployments/scripts/monitor-canary.sh
@@ -1,3 +1,26 @@
 #!/bin/bash
-kubectl get pods -l app=sample-app -o wide
-kubectl get endpoints sample-app-service
+
+echo "=== Canary Deployment Monitor ==="
+echo "Timestamp: $(date)"
+echo "---------------------------------"
+
+echo ""
+echo "📦 Pods by Version:"
+kubectl get pods -l app=sample-app -L version
+
+echo ""
+echo "📊 Deployment Status:"
+kubectl get deploy -l app=sample-app
+
+echo ""
+echo "🌐 Service Endpoints:"
+kubectl get endpoints sample-app-service -o wide
+
+echo ""
+echo "❤️ Pod Health (Ready Status):"
+kubectl get pods -l app=sample-app \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].ready}{"\n"}{end}'
+
+echo ""
+echo "---------------------------------"
+echo "Monitor complete"


### PR DESCRIPTION
**Summary:**

- Added version-based pod visibility using labels.
- Included deployment status for rollout tracking.
- Improved endpoint visibility with wide output.
- Added pod readiness checks.
- Structured output for easier monitoring during canary deployments.

**Why this matters:**
Canary deployments require real-time insights into:

- Which version is running
- Whether new versions are healthy
- How traffic is being distributed

This update makes the script actually useful during rollout decisions instead of just listing resources.