### PR TITLE
Fix staging ConfigMap inconsistency in the kustomize folder

### DIFF
--- a/kustomize/overlays/staging/configmap-patch.yaml
+++ b/kustomize/overlays/staging/configmap-patch.yaml
@@ -8,3 +8,5 @@ data:
   database_host: "staging-db.example.com"
   database_port: "5432"
   debug_mode: "true"
+  cache_enabled: "false"
+  max_connections: "50"


### PR DESCRIPTION
Added missing keys (`cache_enabled`,` max_connections`) to staging ConfigMap to align with production and avoid configuration drift.