### PR TITLE
Implement actual cleanup in cleanup-sidecar for multi-container pod in the multi-container folder

### DIFF
--- a/multi-container/advanced-multi-container.yaml
+++ b/multi-container/advanced-multi-container.yaml
@@ -53,7 +53,9 @@ spec:
     args:
       - |
         while true; do
-          echo "cleanup ok"
+          echo "Performing cleanup..."
+          rm -f /data/output/*.txt
+          echo "Cleanup complete"
           sleep 30
         done
     volumeMounts:


### PR DESCRIPTION
Updated `advanced-multi-container.yaml` so that the `cleanup-sidecar` container removes files in `/data/output` instead of only printing a log message. This prevents accumulation of old output files in long-running pods.