### PR TITLE
Add automated connectivity test for NodePort and Ingress in the networking-ingress folder

### DIFF
--- a/networking-ingress/test-networking.sh
+++ b/networking-ingress/test-networking.sh
@@ -2,11 +2,25 @@
 MINIKUBE_IP=$(minikube ip)
 
 echo "NodePort:"
-curl -s -o /dev/null -w "%{http_code}\n" http://$MINIKUBE_IP:30080
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://$MINIKUBE_IP:30080)
+if [ "$HTTP_CODE" -eq 200 ]; then
+  echo "✓ NodePort accessible (HTTP 200)"
+else
+  echo "✗ NodePort inaccessible (HTTP $HTTP_CODE)"
+fi
 
 echo "Ingress HTTP:"
-curl -s -o /dev/null -w "%{http_code}\n" -H "Host: webapp.local" http://localhost:8080
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Host: webapp.local" http://localhost:8080)
+if [ "$HTTP_CODE" -eq 200 ]; then
+  echo "✓ Ingress HTTP accessible (HTTP 200)"
+else
+  echo "✗ Ingress HTTP inaccessible (HTTP $HTTP_CODE)"
+fi
 
 echo "Ingress HTTPS:"
-curl -k -s -o /dev/null -w "%{http_code}\n" -H "Host: webapp.local" https://localhost:8443
-
+HTTP_CODE=$(curl -k -s -o /dev/null -w "%{http_code}" -H "Host: webapp.local" https://localhost:8443)
+if [ "$HTTP_CODE" -eq 200 ]; then
+  echo "✓ Ingress HTTPS accessible (HTTP 200)"
+else
+  echo "✗ Ingress HTTPS inaccessible (HTTP $HTTP_CODE)"
+fi


### PR DESCRIPTION
- Adds `test-networking.sh` improvements to verify HTTP status codes for NodePort, Ingress HTTP, and HTTPS.
- Provides clear pass/fail output for quick validation of web-app networking.